### PR TITLE
Detect SoC via riscv_hwprobe; unify board labels

### DIFF
--- a/control-plane/cmd/ghfe/payload.go
+++ b/control-plane/cmd/ghfe/payload.go
@@ -3,8 +3,9 @@
 package main
 
 import (
-	"github.com/riseproject-dev/riscv-runner/control-plane/internal"
 	"slices"
+
+	"github.com/riseproject-dev/riscv-runner/control-plane/internal"
 )
 
 // senderDropKeys / repoDropKeys / repoOwnerDropKeys / orgDropKeys /
@@ -104,7 +105,7 @@ func matchLabelsToK8s(cfg internal.Config, orgID int64, repoFullName string, lab
 			(repoFullName == "riseproject-dev/llama.cpp" || repoFullName == "riseproject-dev/llama.cpp-validation"))
 	if isGGMLScope {
 		if len(labels) == 1 && labels[0] == "ubuntu-24.04-riscv" {
-			return "cloudv10x-jupiter", cfg.ImageUbuntu24, true
+			return "spacemit-k1", cfg.ImageUbuntu24, true
 		}
 		return "", "", false
 	}
@@ -112,7 +113,7 @@ func matchLabelsToK8s(cfg internal.Config, orgID int64, repoFullName string, lab
 	isMengZhuoScope := orgID == internal.MengZhuoUserID
 	if isMengZhuoScope {
 		if len(labels) == 1 && labels[0] == "ubuntu-24.04-riscv" {
-			return "cloudv10x-jupiter", cfg.ImageUbuntu24, true
+			return "spacemit-k1", cfg.ImageUbuntu24, true
 		}
 	}
 
@@ -124,13 +125,13 @@ func matchLabelsToK8s(cfg internal.Config, orgID int64, repoFullName string, lab
 	}
 
 	if len(labels) == 1 && labels[0] == "ubuntu-24.04-riscv" {
-		return "scw-em-rv1", cfg.ImageUbuntu24, true
+		return "scaleway-em-rv1", cfg.ImageUbuntu24, true
 	}
 	if len(labels) == 2 && slices.Contains(labels, "ubuntu-24.04-riscv") && slices.Contains(labels, "rva23") {
-		return "spacemit-k3-pico-itx", cfg.ImageUbuntu24, true
+		return "spacemit-k3", cfg.ImageUbuntu24, true
 	}
 	if len(labels) == 1 && labels[0] == "ubuntu-26.04-riscv" {
-		return "spacemit-k3-pico-itx", cfg.ImageUbuntu26, true
+		return "spacemit-k3", cfg.ImageUbuntu26, true
 	}
 	return "", "", false
 }

--- a/control-plane/cmd/ghfe/payload_test.go
+++ b/control-plane/cmd/ghfe/payload_test.go
@@ -82,14 +82,14 @@ func TestMatchLabelsToK8s(t *testing.T) {
 		wantImage string
 		wantOK    bool
 	}{
-		{"general ubuntu-24", 999, "x/y", []string{"ubuntu-24.04-riscv"}, "scw-em-rv1", cfg.ImageUbuntu24, true},
-		{"general ubuntu-26", 999, "x/y", []string{"ubuntu-26.04-riscv"}, "spacemit-k3-pico-itx", cfg.ImageUbuntu26, true},
+		{"general ubuntu-24", 999, "x/y", []string{"ubuntu-24.04-riscv"}, "scaleway-em-rv1", cfg.ImageUbuntu24, true},
+		{"general ubuntu-26", 999, "x/y", []string{"ubuntu-26.04-riscv"}, "spacemit-k3", cfg.ImageUbuntu26, true},
 		{"general no labels", 999, "x/y", []string{}, "", "", false},
 		{"general other", 999, "x/y", []string{"ubuntu-98.04-riscv"}, "", "", false},
 
-		{"ggml ubuntu-24", internal.GGMLOrgID, "ggml/llama.cpp", []string{"ubuntu-24.04-riscv"}, "cloudv10x-jupiter", cfg.ImageUbuntu24, true},
+		{"ggml ubuntu-24", internal.GGMLOrgID, "ggml/llama.cpp", []string{"ubuntu-24.04-riscv"}, "spacemit-k1", cfg.ImageUbuntu24, true},
 		{"ggml with extra label", internal.GGMLOrgID, "ggml/llama.cpp", []string{"ubuntu-24.04-riscv", "extra"}, "", "", false},
-		{"riseproject llama.cpp ubuntu-24", internal.RiseprojectDevOrgID, "riseproject-dev/llama.cpp", []string{"ubuntu-24.04-riscv"}, "cloudv10x-jupiter", cfg.ImageUbuntu24, true},
+		{"riseproject llama.cpp ubuntu-24", internal.RiseprojectDevOrgID, "riseproject-dev/llama.cpp", []string{"ubuntu-24.04-riscv"}, "spacemit-k1", cfg.ImageUbuntu24, true},
 	}
 
 	for _, tc := range tests {

--- a/control-plane/cmd/scheduler/demand_match_test.go
+++ b/control-plane/cmd/scheduler/demand_match_test.go
@@ -31,11 +31,11 @@ func TestDemandMatch_SkipsWhenSlotsNonPositive(t *testing.T) {
 		JobID: 1, Status: "pending", Provider: "github",
 		EntityID: 1, EntityName: "e", EntityType: "Organization",
 		RepoFullName: "e/r", InstallationID: 9,
-		K8sPool: "scw-em-rv1", K8sImage: "img",
+		K8sPool: "scaleway-em-rv1", K8sImage: "img",
 	}}
 	db.SetPoolDemand(1, nil, 5, 0) // demand > supply
 
-	kube.SlotsByPool["scw-em-rv1"] = 0
+	kube.SlotsByPool["scaleway-em-rv1"] = 0
 	if err := app.demandMatch(context.Background()); err != nil {
 		t.Fatalf("demandMatch: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestDemandMatch_SkipsWhenSlotsNonPositive(t *testing.T) {
 		t.Fatalf("expected no provisioning, got %v", kube.ProvisionCalls)
 	}
 
-	kube.SlotsByPool["scw-em-rv1"] = -2
+	kube.SlotsByPool["scaleway-em-rv1"] = -2
 	if err := app.demandMatch(context.Background()); err != nil {
 		t.Fatalf("demandMatch: %v", err)
 	}
@@ -60,16 +60,16 @@ func TestDemandMatch_CapacityFetchedOncePerPool(t *testing.T) {
 			JobID: i, Status: "pending", Provider: "github",
 			EntityID: 1, EntityName: "e", EntityType: "Organization",
 			RepoFullName: "e/r", InstallationID: 9,
-			K8sPool: "scw-em-rv1", K8sImage: "img",
+			K8sPool: "scaleway-em-rv1", K8sImage: "img",
 		})
 	}
 	db.SetPoolDemand(1, nil, 3, 0)
-	kube.SlotsByPool["scw-em-rv1"] = 5
+	kube.SlotsByPool["scaleway-em-rv1"] = 5
 
 	if err := app.demandMatch(context.Background()); err != nil {
 		t.Fatalf("demandMatch: %v", err)
 	}
-	calls := kube.SlotCalls["scw-em-rv1"]
+	calls := kube.SlotCalls["scaleway-em-rv1"]
 	if calls != 1 {
 		t.Fatalf("AvailableSlots called %d times, expected 1", calls)
 	}
@@ -82,10 +82,10 @@ func TestProvisionRunner_FailureMarksWorker(t *testing.T) {
 		JobID: 1, Status: "pending", Provider: "github",
 		EntityID: 1, EntityName: "e", EntityType: "Organization",
 		RepoFullName: "e/r", InstallationID: 9,
-		K8sPool: "scw-em-rv1", K8sImage: "img",
+		K8sPool: "scaleway-em-rv1", K8sImage: "img",
 	}}
 	db.SetPoolDemand(1, nil, 1, 0)
-	kube.SlotsByPool["scw-em-rv1"] = 1
+	kube.SlotsByPool["scaleway-em-rv1"] = 1
 	kube.OnProvisionRunner = func(_, _, _, _ string, _ internal.Entity) error {
 		return errors.New("boom")
 	}
@@ -108,11 +108,11 @@ func TestDemandMatch_RespectsEntityMaxWorkers(t *testing.T) {
 		JobID: 1, Status: "pending", Provider: "github",
 		EntityID: internal.PyTorchOrgID, EntityName: "pytorch", EntityType: "Organization",
 		RepoFullName: "pytorch/pytorch", InstallationID: 9,
-		K8sPool: "scw-em-rv1", K8sImage: "img",
+		K8sPool: "scaleway-em-rv1", K8sImage: "img",
 	}}
 	db.SetPoolDemand(internal.PyTorchOrgID, nil, 1, 0)
 	db.EntityWorkerCnt[internal.PyTorchOrgID] = 20 // at cap
-	kube.SlotsByPool["scw-em-rv1"] = 5
+	kube.SlotsByPool["scaleway-em-rv1"] = 5
 
 	if err := app.demandMatch(context.Background()); err != nil {
 		t.Fatalf("demandMatch: %v", err)

--- a/control-plane/cmd/scheduler/handlers_test.go
+++ b/control-plane/cmd/scheduler/handlers_test.go
@@ -180,7 +180,7 @@ func TestUsage_DBError(t *testing.T) {
 // TestHistory_RendersJobs covers /history HTML + the no-jobs branch.
 func TestHistory_RendersJobs(t *testing.T) {
 	app, db, _, _ := schedTestApp()
-	db.Jobs = []internal.Job{{JobID: 7, Status: "completed", EntityName: "acme", RepoFullName: "acme/r", K8sPool: "scw-em-rv1"}}
+	db.Jobs = []internal.Job{{JobID: 7, Status: "completed", EntityName: "acme", RepoFullName: "acme/r", K8sPool: "scaleway-em-rv1"}}
 
 	r := httptest.NewRequest("GET", "/history", nil)
 	w := httptest.NewRecorder()

--- a/control-plane/cmd/scheduler/sync_workers_test.go
+++ b/control-plane/cmd/scheduler/sync_workers_test.go
@@ -15,7 +15,7 @@ func pendingWorker(name string, runningAt *time.Time) internal.Worker {
 	return internal.Worker{
 		PodName: name, Provider: "github",
 		EntityID: 1, EntityName: "e", EntityType: "Organization",
-		InstallationID: 9, K8sPool: "scw-em-rv1", K8sImage: "img",
+		InstallationID: 9, K8sPool: "scaleway-em-rv1", K8sImage: "img",
 		Status: "running", RunningAt: runningAt,
 	}
 }

--- a/control-plane/internal/db_test.go
+++ b/control-plane/internal/db_test.go
@@ -40,7 +40,7 @@ func anyN(n int) []any {
 func jobScanRow() []any {
 	return []any{
 		int64(1), "pending", []byte(`{}`), "github", int64(99), "acme",
-		"Organization", "acme/r", int64(7), []byte(`["x"]`), "scw-em-rv1",
+		"Organization", "acme/r", int64(7), []byte(`["x"]`), "scaleway-em-rv1",
 		"img", nil, nil, time.Now(), time.Now(),
 		nil, nil, nil, nil, nil,
 	}
@@ -49,7 +49,7 @@ func jobScanRow() []any {
 func workerScanRow(name string, status string) []any {
 	return []any{
 		name, "github", int64(99), "acme", "Organization", int64(7), nil,
-		[]byte(`["x"]`), "scw-em-rv1", "img", nil, status, nil,
+		[]byte(`["x"]`), "scaleway-em-rv1", "img", nil, status, nil,
 		time.Now(), nil, nil, time.Now(),
 	}
 }
@@ -77,7 +77,7 @@ func TestAddJob_InsertedAndNotifies(t *testing.T) {
 
 	got, err := db.AddJob(context.Background(), GHJob{ID: 1},
 		Entity{Type: EntityOrganization, Name: "acme", ID: 99},
-		"github", "acme/r", 7, "scw-em-rv1", "img", "", []string{"x"})
+		"github", "acme/r", 7, "scaleway-em-rv1", "img", "", []string{"x"})
 	if err != nil || !got {
 		t.Fatalf("AddJob: got=%v err=%v", got, err)
 	}

--- a/control-plane/internal/k8s.go
+++ b/control-plane/internal/k8s.go
@@ -45,13 +45,13 @@ func NewK8sClientFromInterface(cs kubernetes.Interface) *K8sClient {
 
 // ProvisionRunner creates the runner pod. The exact shape (host-network,
 // privileged, two emptyDir volumes, single container, RUNNER_JITCONFIG env,
-// ephemeral-storage limit on scw-em-* only) is load-bearing. Don't tweak
+// ephemeral-storage limit on scaleway-em-* only) is load-bearing. Don't tweak
 // without a test.
 func (k *K8sClient) ProvisionRunner(ctx context.Context, jitConfig, runnerName, image, pool string, entity Entity) error {
 	limits := corev1.ResourceList{
 		"riseproject.com/runner": resource.MustParse("1"),
 	}
-	if strings.HasPrefix(pool, "scw-em-") {
+	if strings.HasPrefix(pool, "scaleway-em-") {
 		limits["ephemeral-storage"] = resource.MustParse("90Gi")
 	}
 

--- a/control-plane/internal/k8s_test.go
+++ b/control-plane/internal/k8s_test.go
@@ -27,7 +27,7 @@ func fakePod(t *testing.T, k *K8sClient, runnerName string) *corev1.Pod {
 // TestProvisionRunner_UsesHostNetwork asserts pod.spec.hostNetwork=true on every
 // pool — invariant 9de4c35.
 func TestProvisionRunner_UsesHostNetwork(t *testing.T) {
-	for _, pool := range []string{"scw-em-rv1", "cloudv10x-jupiter"} {
+	for _, pool := range []string{"scaleway-em-rv1", "spacemit-k1"} {
 		k := NewK8sClientFromInterface(fake.NewSimpleClientset())
 		if err := k.ProvisionRunner(context.Background(), "jit", "runner-"+pool, "img", pool, Entity{ID: 1, Name: "ent"}); err != nil {
 			t.Fatalf("provision: %v", err)
@@ -43,7 +43,7 @@ func TestProvisionRunner_UsesHostNetwork(t *testing.T) {
 // /var/lib/docker and /var/lib/k0s exist on every pool (invariants 0028278/653a5ba).
 func TestProvisionRunner_EmptyDirVolumes(t *testing.T) {
 	k := NewK8sClientFromInterface(fake.NewSimpleClientset())
-	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scw-em-rv1", Entity{ID: 1, Name: "ent"}); err != nil {
+	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scaleway-em-rv1", Entity{ID: 1, Name: "ent"}); err != nil {
 		t.Fatalf("provision: %v", err)
 	}
 	p := fakePod(t, k, "r")
@@ -76,16 +76,16 @@ func TestProvisionRunner_EmptyDirVolumes(t *testing.T) {
 	}
 }
 
-// TestProvisionRunner_DiskLimitsOnlyOnScwEM asserts ephemeral-storage=90Gi
-// only on scw-em-* pools (invariant 3286cf6).
-func TestProvisionRunner_DiskLimitsOnlyOnScwEM(t *testing.T) {
+// TestProvisionRunner_DiskLimitsOnlyOnScalewayEM asserts ephemeral-storage=90Gi
+// only on scaleway-em-* pools (invariant 3286cf6).
+func TestProvisionRunner_DiskLimitsOnlyOnScalewayEM(t *testing.T) {
 	tests := []struct {
 		pool     string
 		wantDisk bool
 	}{
-		{"scw-em-rv1", true},
-		{"scw-em-something", true},
-		{"cloudv10x-jupiter", false},
+		{"scaleway-em-rv1", true},
+		{"scaleway-em-something", true},
+		{"spacemit-k1", false},
 	}
 	for _, tc := range tests {
 		k := NewK8sClientFromInterface(fake.NewSimpleClientset())
@@ -115,7 +115,7 @@ func TestProvisionRunner_DiskLimitsOnlyOnScwEM(t *testing.T) {
 // docker-certs volume, no DOCKER_* env (invariant 5c5004f).
 func TestProvisionRunner_NoSidecar(t *testing.T) {
 	k := NewK8sClientFromInterface(fake.NewSimpleClientset())
-	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scw-em-rv1", Entity{ID: 1, Name: "ent"}); err != nil {
+	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scaleway-em-rv1", Entity{ID: 1, Name: "ent"}); err != nil {
 		t.Fatalf("provision: %v", err)
 	}
 	p := fakePod(t, k, "r")
@@ -153,7 +153,7 @@ func mustHaveEnv(t *testing.T, env []corev1.EnvVar, name, value string) {
 // TestProvisionRunner_Labels asserts the four pod labels are set.
 func TestProvisionRunner_Labels(t *testing.T) {
 	k := NewK8sClientFromInterface(fake.NewSimpleClientset())
-	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scw-em-rv1", Entity{ID: 42, Name: "pytorch"}); err != nil {
+	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scaleway-em-rv1", Entity{ID: 42, Name: "pytorch"}); err != nil {
 		t.Fatalf("provision: %v", err)
 	}
 	p := fakePod(t, k, "r")
@@ -161,14 +161,14 @@ func TestProvisionRunner_Labels(t *testing.T) {
 		"app":                         "rise-riscv-runner",
 		"riseproject.dev/entity_id":   "42",
 		"riseproject.dev/entity_name": "pytorch",
-		"riseproject.dev/board":       "scw-em-rv1",
+		"riseproject.dev/board":       "scaleway-em-rv1",
 	}
 	for k, v := range want {
 		if p.Labels[k] != v {
 			t.Errorf("label %s=%q want %q", k, p.Labels[k], v)
 		}
 	}
-	if p.Spec.NodeSelector["riseproject.dev/board"] != "scw-em-rv1" {
+	if p.Spec.NodeSelector["riseproject.dev/board"] != "scaleway-em-rv1" {
 		t.Errorf("nodeSelector board mismatch: %v", p.Spec.NodeSelector)
 	}
 }
@@ -177,7 +177,7 @@ func TestProvisionRunner_Labels(t *testing.T) {
 // activeDeadlineSeconds=525600, restartPolicy=Never, container privileged=true.
 func TestProvisionRunner_TimeoutsAndPrivileged(t *testing.T) {
 	k := NewK8sClientFromInterface(fake.NewSimpleClientset())
-	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scw-em-rv1", Entity{ID: 1, Name: "ent"}); err != nil {
+	if err := k.ProvisionRunner(context.Background(), "jit", "r", "img", "scaleway-em-rv1", Entity{ID: 1, Name: "ent"}); err != nil {
 		t.Fatalf("provision: %v", err)
 	}
 	p := fakePod(t, k, "r")
@@ -226,16 +226,16 @@ func makePod(name, board string, phase corev1.PodPhase) *corev1.Pod {
 
 func TestAvailableSlots_TotalMinusActive(t *testing.T) {
 	cs := fake.NewSimpleClientset(
-		makeNode("n1", "scw-em-rv1", 3),
-		makeNode("n2", "scw-em-rv1", 2),
-		makeNode("other", "cloudv10x-jupiter", 5), // different board, ignored
-		makePod("p1", "scw-em-rv1", corev1.PodPending),
-		makePod("p2", "scw-em-rv1", corev1.PodRunning),
-		makePod("p3", "scw-em-rv1", corev1.PodSucceeded), // terminal, doesn't count
-		makePod("po", "cloudv10x-jupiter", corev1.PodRunning),
+		makeNode("n1", "scaleway-em-rv1", 3),
+		makeNode("n2", "scaleway-em-rv1", 2),
+		makeNode("other", "spacemit-k1", 5), // different board, ignored
+		makePod("p1", "scaleway-em-rv1", corev1.PodPending),
+		makePod("p2", "scaleway-em-rv1", corev1.PodRunning),
+		makePod("p3", "scaleway-em-rv1", corev1.PodSucceeded), // terminal, doesn't count
+		makePod("po", "spacemit-k1", corev1.PodRunning),
 	)
 	k := NewK8sClientFromInterface(cs)
-	cap, err := k.AvailableSlots(context.Background(), "scw-em-rv1")
+	cap, err := k.AvailableSlots(context.Background(), "scaleway-em-rv1")
 	if err != nil {
 		t.Fatalf("AvailableSlots: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestAvailableSlots_TotalMinusActive(t *testing.T) {
 
 func TestAvailableSlots_NoMatchingNodes(t *testing.T) {
 	k := NewK8sClientFromInterface(fake.NewSimpleClientset())
-	cap, err := k.AvailableSlots(context.Background(), "scw-em-rv1")
+	cap, err := k.AvailableSlots(context.Background(), "scaleway-em-rv1")
 	if err != nil {
 		t.Fatalf("AvailableSlots: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestAvailableSlots_NoMatchingNodes(t *testing.T) {
 
 func TestListPods_FiltersByAppLabel(t *testing.T) {
 	cs := fake.NewSimpleClientset(
-		makePod("r1", "scw-em-rv1", corev1.PodRunning),
+		makePod("r1", "scaleway-em-rv1", corev1.PodRunning),
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "noise", Namespace: "default",
@@ -284,7 +284,7 @@ func TestDeletePod_404IsSilentSuccess(t *testing.T) {
 }
 
 func TestDeletePod_Deletes(t *testing.T) {
-	cs := fake.NewSimpleClientset(makePod("p", "scw-em-rv1", corev1.PodSucceeded))
+	cs := fake.NewSimpleClientset(makePod("p", "scaleway-em-rv1", corev1.PodSucceeded))
 	k := NewK8sClientFromInterface(cs)
 	if err := k.DeletePod(context.Background(), "p"); err != nil {
 		t.Fatalf("DeletePod: %v", err)
@@ -295,7 +295,7 @@ func TestDeletePod_Deletes(t *testing.T) {
 }
 
 func TestKillPod_PatchesActiveDeadlineSeconds(t *testing.T) {
-	cs := fake.NewSimpleClientset(makePod("p", "scw-em-rv1", corev1.PodRunning))
+	cs := fake.NewSimpleClientset(makePod("p", "scaleway-em-rv1", corev1.PodRunning))
 	k := NewK8sClientFromInterface(cs)
 	if err := k.KillPod(context.Background(), "p"); err != nil {
 		t.Fatalf("KillPod: %v", err)

--- a/runner/device-plugin/README.md
+++ b/runner/device-plugin/README.md
@@ -81,7 +81,7 @@ resources:
   limits:
     riseproject.com/runner: "1"
 nodeSelector:
-  riseproject.dev/board: scw-em-rv1
+  riseproject.dev/board: scaleway-em-rv1
 ```
 
 The combination guarantees exclusive node access (one runner pod per node) and lands the pod on the right hardware. The scheduler in `control-plane/cmd/scheduler/` sets both fields when provisioning.

--- a/runner/device-plugin/cmd/k8s-device-plugin/main.go
+++ b/runner/device-plugin/cmd/k8s-device-plugin/main.go
@@ -24,14 +24,18 @@ func main() {
 		klog.Fatal("NODE_NAME environment variable is required")
 	}
 
-	board := soc.DetectBoard()
-	klog.Infof("Detected board: %s", board)
+	detected, err := soc.Detect()
+	if err != nil {
+		klog.Fatalf("Failed to detect SoC: %v", err)
+	}
+	klog.Infof("Detected board: %s (mvendorid=%#x marchid=%#x mimpid=%#x)",
+		detected.Name, detected.ID.MVendorID, detected.ID.MArchID, detected.ID.MImpID)
 
-	if err := labeler.LabelNode(nodeName, board); err != nil {
+	if err := labeler.LabelNode(nodeName, detected.Name); err != nil {
 		klog.Fatalf("Failed to label node: %v", err)
 	}
 
-	p := plugin.New()
+	p := plugin.New(detected)
 	if err := p.Start(); err != nil {
 		klog.Fatalf("Failed to start device plugin: %v", err)
 	}

--- a/runner/device-plugin/go.mod
+++ b/runner/device-plugin/go.mod
@@ -6,6 +6,7 @@ go 1.26.0
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1
+	golang.org/x/sys v0.45.0
 	google.golang.org/grpc v1.83.0
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
@@ -34,7 +35,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/runner/device-plugin/pkg/plugin/plugin.go
+++ b/runner/device-plugin/pkg/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/riseproject-dev/riscv-runner/runner/device-plugin/pkg/soc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
@@ -28,13 +29,15 @@ const (
 // to control CI job concurrency.
 type Plugin struct {
 	pluginapi.UnimplementedDevicePluginServer
+	soc    soc.SoC
 	server *grpc.Server
 	socket string
 	stop   chan struct{}
 }
 
-func New() *Plugin {
+func New(soc soc.SoC) *Plugin {
 	return &Plugin{
+		soc:    soc,
 		socket: filepath.Join(socketDir, socketName),
 		stop:   make(chan struct{}),
 	}

--- a/runner/device-plugin/pkg/soc/detect.go
+++ b/runner/device-plugin/pkg/soc/detect.go
@@ -3,48 +3,90 @@
 package soc
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"k8s.io/klog/v2"
 )
 
-// boardMap maps device tree compatible strings to board names.
-var boardMap = map[string]string{
-	"scaleway,em-rv1-c4m16s128-a": "scw-em-rv1",
-	"spacemit,k1-x":               "cloudv10x-jupiter",
-	"V100-C2201":                  "spacemit-v100",
+// SoCID is the riscv_hwprobe hardware identity triple.
+type SoCID struct {
+	MVendorID uint64
+	MArchID   uint64
+	MImpID    uint64
 }
 
-// DetectBoard reads the device tree compatible property and maps it to a board name.
-func DetectBoard() string {
+type SoC struct {
+	ID   SoCID
+	Name string
+}
+
+// socs is the hand-maintained list of known SoCs, keyed by the riscv_hwprobe
+// identity triple. Read the "riscv_hwprobe IDs: ..." log line on a node to add
+// an entry.
+var socs = []SoC{
+	{Name: "spacemit-k1", ID: SoCID{MVendorID: 0x0000000000000710, MArchID: 0x8000000058000001, MImpID: 0x1000000049772200}},
+	{Name: "spacemit-k3", ID: SoCID{MVendorID: 0x0000000000000710, MArchID: 0x8000000058000002, MImpID: 0x0000000033d8a600}},
+	{Name: "spacemit-v100", ID: SoCID{MVendorID: 0x0000000000000710, MArchID: 0x8000000058000002, MImpID: 0x0000000004c4d900}},
+}
+
+// scalewayEMRV1 is identified by device tree, not hwprobe: its kernel lacks the
+// syscall. The ID triple is known and filled in by hand for observability.
+var scalewayEMRV1 = SoC{
+	Name: "scaleway-em-rv1",
+	ID:   SoCID{MVendorID: 0x0, MArchID: 0x0, MImpID: 0x0},
+}
+
+// Detect identifies the SoC from the riscv_hwprobe (mvendorid, marchid, mimpid)
+// triple. The Scaleway EM-RV1 is special-cased: its kernel lacks the syscall, so
+// on probe failure Detect falls back to the device tree for that board alone.
+// Anything unrecognized errors, so a node fails loudly rather than mislabeling.
+func Detect() (SoC, error) {
+	id, err := probeHWID()
+	if err != nil {
+		klog.Warningf("riscv_hwprobe failed (%v), falling back to device tree", err)
+		return detectFromDeviceTree(err)
+	}
+	klog.Infof("riscv_hwprobe IDs: mvendorid=%#x marchid=%#x mimpid=%#x",
+		id.MVendorID, id.MArchID, id.MImpID)
+	s, ok := match(id)
+	if !ok {
+		return SoC{}, fmt.Errorf("no known SoC for riscv_hwprobe IDs "+
+			"mvendorid=%#x marchid=%#x mimpid=%#x", id.MVendorID, id.MArchID, id.MImpID)
+	}
+	return s, nil
+}
+
+func match(id SoCID) (SoC, bool) {
+	for _, s := range socs {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return SoC{}, false
+}
+
+// detectFromDeviceTree recognizes only the Scaleway EM-RV1. Any other board is
+// reported as the original probe failure.
+func detectFromDeviceTree(probeErr error) (SoC, error) {
 	compatible := readCompatible()
-	if compatible != "" {
-		entries := strings.Split(compatible, "\x00")
-		klog.Infof("Device tree compatible entries: %v", entries)
-		for _, entry := range entries {
-			entry = strings.TrimSpace(entry)
-			klog.Infof("Checking compatible entry: '%s'", entry)
-			if entry == "" {
-				continue
-			}
-			if board, ok := boardMap[entry]; ok {
-				klog.Infof("Matched compatible '%s' to board '%s'", entry, board)
-				return board
-			}
+	if matchScaleway(compatible) {
+		return scalewayEMRV1, nil
+	}
+	return SoC{}, fmt.Errorf("riscv_hwprobe failed and device tree is not a known board: %w", probeErr)
+}
+
+// matchScaleway reports whether a device tree "compatible" property (a set of
+// null-separated strings) identifies a Scaleway EM-RV1.
+func matchScaleway(compatible string) bool {
+	const scalewayCompatible = "scaleway,em-rv1"
+	for _, entry := range strings.Split(compatible, "\x00") {
+		if strings.HasPrefix(strings.TrimSpace(entry), scalewayCompatible) {
+			return true
 		}
 	}
-
-	product_name := readProductName()
-	if product_name != "" {
-		klog.Infof("Checking product name: %s", product_name)
-		if board, ok := boardMap[product_name]; ok {
-			klog.Infof("Matched product name '%s' to board '%s'", product_name, board)
-			return board
-		}
-	}
-
-	return "<unknown>"
+	return false
 }
 
 func readCompatible() string {
@@ -55,32 +97,10 @@ func readCompatible() string {
 	for _, p := range paths {
 		data, err := os.ReadFile(p)
 		if err == nil {
-			klog.Infof("Read compatible string from %s: %s", p, string(data))
+			klog.Infof("Read device tree compatible from %s: %q", p, string(data))
 			return string(data)
 		}
 	}
-	klog.Warning("Failed to read compatible string from known paths")
+	klog.Warning("Failed to read device tree compatible from known paths")
 	return ""
-}
-
-func readProductName() string {
-	paths := []string{
-		"/sys/devices/virtual/dmi/id/product_name",
-	}
-	for _, p := range paths {
-		data, err := os.ReadFile(p)
-		if err == nil {
-			klog.Infof("Read product name from %s: %s", p, string(data))
-			return strings.TrimSpace(string(data))
-		}
-	}
-	klog.Warning("Failed to read product name from known paths")
-	return ""
-}
-
-func sanitize(s string) string {
-	s = strings.ReplaceAll(s, ",", "-")
-	s = strings.ReplaceAll(s, " ", "-")
-	s = strings.ToLower(s)
-	return s
 }

--- a/runner/device-plugin/pkg/soc/detect_test.go
+++ b/runner/device-plugin/pkg/soc/detect_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+package soc
+
+import "testing"
+
+func TestMatch(t *testing.T) {
+	socs = []SoC{
+		{Name: "test-soc", ID: SoCID{MVendorID: 0x710, MArchID: 0x8000000058000001, MImpID: 0x1}},
+	}
+
+	tests := []struct {
+		name     string
+		id       SoCID
+		wantName string
+		wantOK   bool
+	}{
+		{
+			name:     "hit",
+			id:       SoCID{MVendorID: 0x710, MArchID: 0x8000000058000001, MImpID: 0x1},
+			wantName: "test-soc",
+			wantOK:   true,
+		},
+		{
+			name:   "miss on mimpid",
+			id:     SoCID{MVendorID: 0x710, MArchID: 0x8000000058000001, MImpID: 0x2},
+			wantOK: false,
+		},
+		{
+			name:   "miss on all zero",
+			id:     SoCID{},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := match(tt.id)
+			if ok != tt.wantOK {
+				t.Fatalf("match(%+v) ok = %v, want %v", tt.id, ok, tt.wantOK)
+			}
+			if ok && got.Name != tt.wantName {
+				t.Errorf("match(%+v) name = %q, want %q", tt.id, got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMatchScaleway(t *testing.T) {
+	tests := []struct {
+		name       string
+		compatible string
+		want       bool
+	}{
+		{"exact prefix", "scaleway,em-rv1-c4m16s128-a", true},
+		{"trailing entries", "scaleway,em-rv1\x00riscv", true},
+		{"leading whitespace", "  scaleway,em-rv1  ", true},
+		{"other board", "spacemit,k1-x", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchScaleway(tt.compatible); got != tt.want {
+				t.Errorf("matchScaleway(%q) = %v, want %v", tt.compatible, got, tt.want)
+			}
+		})
+	}
+}

--- a/runner/device-plugin/pkg/soc/hwprobe_riscv64.go
+++ b/runner/device-plugin/pkg/soc/hwprobe_riscv64.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+//go:build riscv64 && linux
+
+package soc
+
+import "golang.org/x/sys/unix"
+
+func probeHWID() (SoCID, error) {
+	pairs := []unix.RISCVHWProbePairs{
+		{Key: unix.RISCV_HWPROBE_KEY_MVENDORID},
+		{Key: unix.RISCV_HWPROBE_KEY_MARCHID},
+		{Key: unix.RISCV_HWPROBE_KEY_MIMPID},
+	}
+	if err := unix.RISCVHWProbe(pairs, nil, 0); err != nil {
+		return SoCID{}, err
+	}
+	var id SoCID
+	for _, p := range pairs {
+		switch p.Key {
+		case unix.RISCV_HWPROBE_KEY_MVENDORID:
+			id.MVendorID = p.Value
+		case unix.RISCV_HWPROBE_KEY_MARCHID:
+			id.MArchID = p.Value
+		case unix.RISCV_HWPROBE_KEY_MIMPID:
+			id.MImpID = p.Value
+		}
+	}
+	return id, nil
+}

--- a/runner/device-plugin/pkg/soc/hwprobe_stub.go
+++ b/runner/device-plugin/pkg/soc/hwprobe_stub.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !(riscv64 && linux)
+
+package soc
+
+import "errors"
+
+func probeHWID() (SoCID, error) {
+	return SoCID{}, errors.New("riscv_hwprobe is only supported on riscv64 linux")
+}

--- a/website/docs/architecture/ghfe.md
+++ b/website/docs/architecture/ghfe.md
@@ -56,8 +56,8 @@ Unhandled `X-GitHub-Event` headers are recorded with `outcome=unhandled_event` a
 
 | Scope | Label | Pool | Image |
 |---|---|---|---|
-| Default | `ubuntu-24.04-riscv` | `scw-em-rv1` | `riscv-runner:ubuntu-24.04-prod` (or `-staging`) |
-| GGML scope: `ggml-org/*`, `riseproject-dev/llama.cpp`, `riseproject-dev/llama.cpp-validation` | `ubuntu-24.04-riscv` | `cloudv10x-jupiter` | `riscv-runner:ubuntu-24.04-prod` (or `-staging`) |
+| Default | `ubuntu-24.04-riscv` | `scaleway-em-rv1` | `riscv-runner:ubuntu-24.04-prod` (or `-staging`) |
+| GGML scope: `ggml-org/*`, `riseproject-dev/llama.cpp`, `riseproject-dev/llama.cpp-validation` | `ubuntu-24.04-riscv` | `spacemit-k1` | `riscv-runner:ubuntu-24.04-prod` (or `-staging`) |
 
 The handler only matches single-label arrays containing `ubuntu-24.04-riscv` today. Anything else returns `(_, _, false)` and is ignored with `outcome=IGNORED_NO_LABEL`. New labels are added by extending `matchLabelsToK8s`.
 

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -69,7 +69,7 @@ sequenceDiagram
 
 **Two GitHub Apps.** Organizations and personal accounts use separate GitHub Apps. The org app uses organization-level runner registration (requires Self-hosted runners permission). The personal app uses repository-level runner registration (requires Administration permission). The worker selects the correct app and API path based on entity type.
 
-**Board-based scheduling.** The device plugin reads the device tree on each RISC-V node at startup, detects the SoC, and applies a `riseproject.dev/board` label. Runner pods use a `nodeSelector` to land on the correct hardware for each label.
+**Board-based scheduling.** The device plugin probes each RISC-V node at startup with the `riscv_hwprobe` syscall, identifies the SoC from its `mvendorid`/`marchid`/`mimpid` triple, and applies a `riseproject.dev/board` label. Runner pods use a `nodeSelector` to land on the correct hardware for each label.
 
 ## Components
 

--- a/website/docs/architecture/kubernetes.md
+++ b/website/docs/architecture/kubernetes.md
@@ -15,29 +15,27 @@ The device plugin runs as a DaemonSet on every RISC-V node. At startup it labels
 ```mermaid
 flowchart TD
     subgraph Node["RISC-V Node"]
-        DT["/sys/firmware/devicetree/base/compatible"]
-        NL["Node Labeller Pod"]
+        HWP["riscv_hwprobe syscall"]
+        DT["/sys/firmware/devicetree/base/compatible<br/>(Scaleway fallback)"]
         DP["Device Plugin Pod"]
         KL["Kubelet"]
+        RP["Runner Pod"]
     end
 
     subgraph Cluster["Kubernetes Cluster"]
-        API["API Server"]
         SCHED["Scheduler"]
     end
 
-    RP["Runner Pod"]
 
-    DT -->|read device tree| NL
-    NL -->|patch node label| API
-    API -->|"riseproject.dev/board=scw-em-rv1"| Node
+    HWP <-->|"mvendorid, marchid, mimpid"| DP
+    DT <-->|"probe failed: read compatible"| DP
+    DP -->|"patch node label riseproject.dev/board=spacemit-k3"| SCHED
 
-    DP -->|"gRPC: advertise riseproject.com/runner: 1"| KL
-    KL -->|report allocatable resources| API
+    DP -->|"advertise riseproject.com/runner=1"| KL
+    KL -->|report allocatable resources| SCHED
 
-    RP -->|"nodeSelector: riseproject.dev/board"| SCHED
-    RP -->|"limits: riseproject.com/runner: 1"| SCHED
-    SCHED -->|schedule| Node
+    KL -->|schedule| RP
+    SCHED -->|"nodeSelector: riseproject.dev/board\nlimits: riseproject.com/runner=1"| KL
 ```
 
 ## Device plugin
@@ -67,16 +65,20 @@ The device plugin detects the SoC on each RISC-V node at startup and applies a `
 
 ### SoC detection
 
-1. Read `/sys/firmware/devicetree/base/compatible` (null-separated entries)
-2. Match each entry against a built-in board map:
+The primary key is the `riscv_hwprobe(2)` syscall, which returns the hardware identity triple (`mvendorid`, `marchid`, `mimpid`) read from the CPU CSRs.
 
-| Device tree compatible string | Board label |
-|-------------------------------|-------------|
-| `scaleway,em-rv1-c4m16s128-a` | `scw-em-rv1` |
-| `sophgo,mango` | `cloudv10x-pioneer` |
-| `spacemit,k1-x` | `cloudv10x-jupiter` |
+1. Call `riscv_hwprobe` for the three ID keys and log the triple as hex.
+2. Match the triple against a hand-maintained list of known SoCs:
 
-3. If no known mapping exists, sanitize the first compatible entry (replace commas/spaces with hyphens, lowercase) and use that as the label. If the compatible file is missing or empty, the label is set to `<unknown>`.
+| `mvendorid` | `marchid` | `mimpid` | Board label |
+|-------------|-----------|----------|-------------|
+| `0x710` | `0x8000000058000001` | `0x1000000049772200` | `spacemit-k1` |
+| `0x710` | `0x8000000058000002` | `0x33d8a600` | `spacemit-k3` |
+| `0x710` | `0x8000000058000002` | `0x4c4d900` | `spacemit-v100` |
+
+3. If the triple matches no entry, `Detect` returns an error and the plugin exits. An unrecognized node fails loudly rather than mislabelling itself. To add the board, read the logged triple and append an entry to the list.
+
+The Scaleway EM-RV1 is a special case: its kernel predates `riscv_hwprobe`, so the syscall fails. Only on that failure does detection fall back to reading `/sys/firmware/devicetree/base/compatible`; a `scaleway,em-rv1` prefix yields the `scaleway-em-rv1` label. Any other board on a kernel without the syscall is treated as the original probe failure.
 
 ### DaemonSet configuration
 
@@ -86,7 +88,7 @@ The device plugin detects the SoC on each RISC-V node at startup and applies a `
 - **RBAC:** ServiceAccount with ClusterRole granting `get` and `patch` on nodes
 - **Environment:** `NODE_NAME` from downward API (`spec.nodeName`)
 - **Volume mounts:** `/var/lib/kubelet/device-plugins` (host path), `/sys` (read-only host path)
-- **Privileged:** Yes (required for device tree access)
+- **Privileged:** Yes (device tree access for the Scaleway fallback)
 - **Image:** `rg.fr-par.scw.cloud/funcscwriseriscvrunnerappqdvknz9s/riscv-runner:device-plugin-prod`
 
 ## Source files
@@ -95,6 +97,6 @@ The device plugin detects the SoC on each RISC-V node at startup and applies a `
 |------|------|
 | [`cmd/k8s-device-plugin/main.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/cmd/k8s-device-plugin/main.go) | Entry point: label node, then start device plugin |
 | [`pkg/plugin/plugin.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/pkg/plugin/plugin.go) | gRPC server, kubelet registration, watchdog |
-| [`pkg/soc/detect.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/pkg/soc/detect.go) | Device tree parsing and SoC → board mapping |
+| [`pkg/soc/detect.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/pkg/soc/detect.go) | `riscv_hwprobe` triple matching, Scaleway device tree fallback, SoC → board mapping |
 | [`pkg/labeler/labeler.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/pkg/labeler/labeler.go) | Kubernetes API node label patching |
 | [`k8s-ds-device-plugin.yaml`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/k8s-ds-device-plugin.yaml) | DaemonSet + RBAC manifest |

--- a/website/docs/architecture/scheduler.md
+++ b/website/docs/architecture/scheduler.md
@@ -89,7 +89,7 @@ Runner pods are created via the Kubernetes API with:
 - **Labels:** `app=rise-riscv-runner`, `riseproject.dev/board=<pool>`.
 - **Node selector:** `riseproject.dev/board: <pool>` (targets the correct hardware).
 - **Resource limit:** `riseproject.com/runner: 1` (enforces one pod per node via the [device plugin](kubernetes)).
-- **Ephemeral storage:** request 40 Gi, limit 90 Gi (on `scw-em-*` pools only).
+- **Ephemeral storage:** request 40 Gi, limit 90 Gi (on `scaleway-em-*` pools only).
 - **Active deadline:** `525,600` seconds (~6 days). Patched to `1` to kill stuck pods (see Health checks).
 - **Security context:** `privileged: true`, host network. Required by the in-pod Docker daemon to program iptables and bridge devices.
 - **Environment:** `RUNNER_JITCONFIG` (base64 JIT token from GitHub), `RUNNER_WAIT_FOR_DOCKER_IN_SECONDS=60`.

--- a/website/docs/getting-started/labels.md
+++ b/website/docs/getting-started/labels.md
@@ -23,9 +23,9 @@ Each label maps to a Kubernetes node pool, selected by the `riseproject.dev/boar
 
 | Label | Default pool | GGML scope pool |
 |-------|--------------|-----------------|
-| `ubuntu-24.04-riscv` | `scw-em-rv1` | `cloudv10x-jupiter` |
+| `ubuntu-24.04-riscv` | `scaleway-em-rv1` | `spacemit-k1` |
 
-"GGML scope" means jobs running in `ggml-org/*`, `riseproject-dev/llama.cpp`, or `riseproject-dev/llama.cpp-validation`. Those workloads are routed to `cloudv10x-jupiter` (CloudV 10xE Jupiter, SpacemiT K1) hardware.
+"GGML scope" means jobs running in `ggml-org/*`, `riseproject-dev/llama.cpp`, or `riseproject-dev/llama.cpp-validation`. Those workloads are routed to `spacemit-k1` (CloudV 10xE Jupiter, SpacemiT K1) hardware.
 
 ## Runner exclusivity
 

--- a/website/docs/operations/cluster-provisioning.md
+++ b/website/docs/operations/cluster-provisioning.md
@@ -65,7 +65,7 @@ Expected:
 
 ```
   kubernetes.io/arch=riscv64
-  riseproject.dev/board=scw-em-rv1            # or cloudv10x-pioneer / cloudv10x-jupiter
+  riseproject.dev/board=scaleway-em-rv1       # or spacemit-k1, spacemit-k3, spacemit-v100
   riseproject.com/runner:  1                  # under "Allocatable"
 ```
 
@@ -82,7 +82,7 @@ The device plugin has a ServiceAccount in `kube-system` with a ClusterRole grant
 
 When new RISC-V hardware enters the fleet:
 
-1. SSH into a node of the new board and read `/sys/firmware/devicetree/base/compatible`. Note the first NUL-separated entry.
-2. Add a row to `boardMap` in [`runner/device-plugin/pkg/soc/detect.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/pkg/soc/detect.go).
+1. Deploy the device plugin to a node of the new board and read the `riscv_hwprobe IDs: mvendorid=0x... marchid=0x... mimpid=0x...` line from its logs. Until the board is known, `Detect` errors and the plugin exits, which is expected.
+2. Add an entry to the `socs` list in [`runner/device-plugin/pkg/soc/detect.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/runner/device-plugin/pkg/soc/detect.go) with that triple and the board label. (A board whose kernel lacks `riscv_hwprobe`, like the Scaleway EM-RV1, is instead special-cased against the device tree in the same file.)
 3. If the new board needs a dedicated label, extend `matchLabelsToK8s` in [`control-plane/cmd/ghfe/payload.go`](https://github.com/riseproject-dev/riscv-runner/blob/main/control-plane/cmd/ghfe/payload.go) and add the label to [Runner Labels](../getting-started/labels).
 4. Push and let the device-plugin deploy workflow roll out the new labeller.


### PR DESCRIPTION
- device-plugin reads mvendorid/marchid/mimpid from riscv_hwprobe and
  matches a hand-maintained SoC list; scaleway-em-rv1 falls back to the
  device tree (its kernel lacks the syscall), unknown SoC crashes.
- rename labels: scw-em-rv1 -> scaleway-em-rv1, spacemit-k3-pico-itx ->
  spacemit-k3, cloudv10x-jupiter -> spacemit-k1.
- ephemeral-storage limit now gates on the scaleway-em- prefix.
